### PR TITLE
improved Paginated Collection

### DIFF
--- a/src/Sorskod/Larasponse/Providers/Fractal.php
+++ b/src/Sorskod/Larasponse/Providers/Fractal.php
@@ -51,7 +51,14 @@ class Fractal implements Larasponse
 
         $resource = new Collection($paginator->getCollection(), $this->getTransformer($transformer), $resourceKey);
 
-        $resource->setPaginator(new IlluminatePaginatorAdapter($paginator));
+        $paginatorAdapter = new IlluminatePaginatorAdapter($paginator);
+
+        $queryParams = array_diff_key($_GET, array_flip(['page']));
+        foreach ($queryParams as $key => $value) {
+            $paginatorAdapter->addQuery($key, $value);
+        }
+
+        $resource->setPaginator($paginatorAdapter);
 
         return $this->manager->createData($resource)->toArray();
     }
@@ -71,4 +78,4 @@ class Fractal implements Larasponse
             return (array) $data;
         };
     }
-} 
+}


### PR DESCRIPTION
This pull request fixes the next/previous links within the metadata of a Paginated Collection when additional query string parameters are present, using the suggested code found in the official Fractal Documentation on [Pagination](http://fractal.thephpleague.com/pagination/) 

In the current implementation, if you have 10 items in the collection but use a limit= (applies for include= and all other query string params too)

```
http://example.api/resource?limit=2&include=subresource&page=2
```

the next/prev links generated are simply:

```
links: {
    previous: "http://example.api/resource?page=1",
    next: "http://example.api/resource?page=3"
}
```

so if you use these links, you will be presented the default limit of data with no subresource included etc.

This pull request changes it to:

```
links: {
    previous: "http://example.api/resource?limit=2&include=subresource&page=1",
    next: "http://example.api/resource?limit=2&include=subresource&page=3"
}
```

So you are returned the data you expect on subsequent pages if you make use of these links in your code.
