### PR TITLE
Fixed outdated link to the tutorial

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,4 +65,4 @@ class UserController extends BaseController
 
 ## Read more...
 
-* [Using Fractal with Laravel to create an API](http://mariobasic.com/laravel-fractal/) by @mabasic
+* [Using Fractal with Laravel to create an API](http://laravelista.com/laravel-fractal/) by @mabasic


### PR DESCRIPTION
The mariobasic.com link gives a 404 (actually a Laravel error alert)
