### PR TITLE
Add parseExcludes() method

### DIFF
--- a/src/Sorskod/Larasponse/Providers/Fractal.php
+++ b/src/Sorskod/Larasponse/Providers/Fractal.php
@@ -34,6 +34,11 @@ class Fractal implements Larasponse
     {
         $this->manager->parseIncludes($includes);
     }
+    
+    public function parseExcludes($excludes)
+    {
+        $this->manager->parseExcludes($excludes);
+    }
 
     public function collection($data, $transformer = null, $resourceKey = null)
     {


### PR DESCRIPTION
"The Manager::parseExcludes() method is available for odd situations where a default include should be omitted from a single response."

Source: http://fractal.thephpleague.com/transformers/#excluding-includes
